### PR TITLE
Fix getLuminance

### DIFF
--- a/__tests__/Polished/Color/Polished_Color_Utils_test.re
+++ b/__tests__/Polished/Color/Polished_Color_Utils_test.re
@@ -29,3 +29,17 @@ describe("floatInRange", () => {
     expect(1.23->floatInRange(0.0, 1.0)) |> toBe(1.0)
   });
 });
+
+describe("Polished_Color_Utils.getLuminance", () => {
+  test("luminance of black", () => {
+    expect(RGB(RGB.fromPrimitives(0, 0, 0))->getLuminance) |> toBe(0.0)
+  });
+  test("luminance of white", () => {
+    expect(RGB(RGB.fromPrimitives(255, 255, 255))->getLuminance)
+    |> toBe(1.0)
+  });
+  test("luminance of #808080", () => {
+    expect(RGB(RGB.fromPrimitives(128, 128, 128))->getLuminance)
+    |> toBeSoCloseTo(0.21586, ~digits=4)
+  });
+});

--- a/src/Polished/Color/Polished_Color_Utils.re
+++ b/src/Polished/Color/Polished_Color_Utils.re
@@ -172,7 +172,7 @@ let getLuminance = (color: color): float => {
     if (c <= 0.03928) {
       c /. 12.92;
     } else {
-      (c +. 0.055) /. 1.055 ** 2.4;
+      ((c +. 0.055) /. 1.055) ** 2.4;
     };
   let r2 = convert(rc);
   let g2 = convert(gc);


### PR DESCRIPTION
The formula for calculating luminance was wrong (missing parenthesis resulting in incorrect channel value).
Here is fix + tests.