### PR TITLE
Fix convertRGBtoHEX

### DIFF
--- a/__tests__/Polished/Color/Polished_Color_Utils_test.re
+++ b/__tests__/Polished/Color/Polished_Color_Utils_test.re
@@ -3,21 +3,6 @@ open Expect;
 open Polished_Types;
 open Polished_Color_Utils;
 
-describe("convertRGBtoHEX", () => {
-  test("rgba(0,0,0) -> 000000", () => {
-    let rgb = RGB.fromPrimitives(0, 0, 0);
-    expect(rgb->convertRGBtoHEX->HEX.asString) |> toBe("000000");
-  });
-  test("rgba(255,255,255) -> ffffff", () => {
-    let rgb = RGB.fromPrimitives(255, 255, 255);
-    expect(rgb->convertRGBtoHEX->HEX.asString) |> toBe("ffffff");
-  });
-  test("rgba(122,32,65) -> 7a2041", () => {
-    let rgb = RGB.fromPrimitives(122, 32, 65);
-    expect(rgb->convertRGBtoHEX->HEX.asString) |> toBe("7a2041");
-  });
-});
-
 describe("floatInRange", () => {
   test("-0.3 -> 0.0", () => {
     expect((-0.3)->floatInRange(0.0, 1.0)) |> toBe(0.0)
@@ -27,5 +12,22 @@ describe("floatInRange", () => {
   });
   test("1.23 -> 1.00", () => {
     expect(1.23->floatInRange(0.0, 1.0)) |> toBe(1.0)
+  });
+});
+
+describe("Polished_Color_Utils.convertRGBtoHEX", () => {
+  test("convert rgb(0, 0, 0) to #000000", () => {
+    expect(RGB.fromPrimitives(0, 0, 0)->convertRGBtoHEX)
+    |> toEqual(HEX.make("000000"))
+  });
+
+  test("convert rgb(255, 255, 255) to #ffffff", () => {
+    expect(RGB.fromPrimitives(255, 255, 255)->convertRGBtoHEX)
+    |> toEqual(HEX.make("ffffff"))
+  });
+
+  test("convert rgb(0, 128, 255) to #0080ff", () => {
+    expect(RGB.fromPrimitives(0, 128, 255)->convertRGBtoHEX)
+    |> toEqual(HEX.make("0080ff"))
   });
 });

--- a/src/Polished/Color/Polished_Color_Utils.re
+++ b/src/Polished/Color/Polished_Color_Utils.re
@@ -24,9 +24,9 @@ let convertRGBtoHEX = (rgb: RGB.t): HEX.t => {
   let red = rgb->RGB.red;
   let green = rgb->RGB.green;
   let blue = rgb->RGB.blue;
-  let strRed = Printf.sprintf("%x", red->Int8.asInt);
-  let strGreen = Printf.sprintf("%x", green->Int8.asInt);
-  let strBlue = Printf.sprintf("%x", blue->Int8.asInt);
+  let strRed = Printf.sprintf("%02x", red->Int8.asInt);
+  let strGreen = Printf.sprintf("%02x", green->Int8.asInt);
+  let strBlue = Printf.sprintf("%02x", blue->Int8.asInt);
   HEX.make(strRed ++ strGreen ++ strBlue);
 };
 


### PR DESCRIPTION
This function was not working properly if the value of r/g/b was < 16. 
`Printf.sprintf("%x", 0);` returns `"0"` but we need `"00"` otherwise `HEX.make` will receive wrong string.
Fixed by using proper format flat `%02x`.

I have also updated tests to detect this issue.